### PR TITLE
feat: decouple redis client instantiation from pkg/leader.NewRedisLeader

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/spf13/viper"
 	internal_leader "github.com/supertylerc/scheduler/internal/leader"
 	"github.com/supertylerc/scheduler/pkg/leader"
 )
@@ -14,12 +16,14 @@ import (
 func main() {
 	internal_leader.ViperConfig()
 	internal_leader.LogConfig()
-
-	ldr, err := internal_leader.CreateRedisLeader()
+	ctx := context.Background()
+	client, err := internal_leader.CreateRedisClient(ctx, 0)
 	if err != nil {
 		slog.Error("Unable to create leader", slog.String("err", err.Error()))
 		os.Exit(1)
 	}
+	redisLeaderKey := viper.Get("REDIS_LEADER_KEY").(string)
+	ldr, err := leader.NewRedisLeader(client, redisLeaderKey)
 
 	os.Exit(run(ldr))
 }

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -16,14 +16,22 @@ import (
 func main() {
 	internal_leader.ViperConfig()
 	internal_leader.LogConfig()
+
 	ctx := context.Background()
+
 	client, err := internal_leader.CreateRedisClient(ctx, 0)
+	if err != nil {
+		slog.Error("Unable to create Redis Client", slog.String("err", err.Error()))
+		os.Exit(1)
+	}
+
+	redisLeaderKey := viper.Get("REDIS_LEADER_KEY").(string)
+
+	ldr, err := leader.NewRedisLeader(client, redisLeaderKey)
 	if err != nil {
 		slog.Error("Unable to create leader", slog.String("err", err.Error()))
 		os.Exit(1)
 	}
-	redisLeaderKey := viper.Get("REDIS_LEADER_KEY").(string)
-	ldr, err := leader.NewRedisLeader(client, redisLeaderKey)
 
 	os.Exit(run(ldr))
 }

--- a/internal/leader/redis.go
+++ b/internal/leader/redis.go
@@ -1,40 +1,42 @@
 package leader
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
-	"github.com/supertylerc/scheduler/pkg/leader"
 )
 
-func CreateRedisLeader() (*leader.RedisLeader, error) {
+func CreateRedisClient(ctx context.Context, db int) (*redis.Client, error) {
 	redisHost := viper.Get("REDIS_HOST").(string)
 	redisPort := viper.Get("REDIS_PORT").(string)
 	redisPassword := viper.Get("REDIS_PASSWORD").(string)
-	redisLeaderKey := viper.Get("REDIS_LEADER_KEY").(string)
+
 	slog.Debug(
-		"Creating leader",
+		"Creating client",
 		slog.String("redisHost", redisHost),
 		slog.String("redisPort", redisPort),
 		slog.String("redisPassword", redisPassword),
-		slog.String("redisLeaderKey", redisLeaderKey),
+		slog.Int("redisDB", db),
 	)
 
-	ldr, err := leader.NewRedisLeader(
-		fmt.Sprintf("%s:%s", redisHost, redisPort),
-		redisPassword,
-		redisLeaderKey,
-	)
-	if err != nil {
-		return &leader.RedisLeader{}, fmt.Errorf("error creating a Redis Leader: %w", err)
+	redisAddress := fmt.Sprintf("%s:%s", redisHost, redisPort)
+	client := redis.NewClient(&redis.Options{
+		Addr:     redisAddress,
+		Password: redisPassword,
+		DB:       db,
+	})
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("unable to ping Redis: %w", err)
 	}
 
 	slog.Info(
-		"Created new leader",
-		slog.String("uuid", ldr.UUID.String()),
-		slog.String("key", ldr.Key),
+		"Created new redis client",
+		slog.String("address", redisAddress),
+		slog.Int("db", db),
 	)
 
-	return ldr, nil
+	return client, nil
 }

--- a/internal/leader/redis.go
+++ b/internal/leader/redis.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// nolint: varnamelen
 func CreateRedisClient(ctx context.Context, db int) (*redis.Client, error) {
 	redisHost := viper.Get("REDIS_HOST").(string)
 	redisPort := viper.Get("REDIS_PORT").(string)
@@ -28,6 +29,7 @@ func CreateRedisClient(ctx context.Context, db int) (*redis.Client, error) {
 		Password: redisPassword,
 		DB:       db,
 	})
+
 	if err := client.Ping(ctx).Err(); err != nil {
 		return nil, fmt.Errorf("unable to ping Redis: %w", err)
 	}

--- a/pkg/leader/redis.go
+++ b/pkg/leader/redis.go
@@ -27,19 +27,10 @@ type RedisLeader struct {
 	Key    string
 }
 
-func NewRedisLeader(address, password, key string) (*RedisLeader, error) {
+func NewRedisLeader(client *redis.Client, key string) (*RedisLeader, error) {
 	ldrUUID, err := uuid.NewUUID()
 	if err != nil {
 		return nil, fmt.Errorf("error creating UUID: %w", err)
-	}
-
-	client := redis.NewClient(&redis.Options{
-		Addr:     address,
-		Password: password,
-		DB:       0,
-	})
-	if err = client.Ping(Ctx).Err(); err != nil {
-		return nil, fmt.Errorf("unable to ping Redis: %w", err)
 	}
 
 	return &RedisLeader{


### PR DESCRIPTION
Leader shouldn't be responsible for creating the Redis Client.  Refactor to move client instantiation out of `pkg/leader.NewRedisLeader`.  This will make testing easier.  It will also abstract client creation for multiple DBs if we choose to use a different DB than the Leader DB for pub/sub.